### PR TITLE
削除済みのリマインダーに関するバグを修正

### DIFF
--- a/src/shared/services/User/UserRemindHistory.js
+++ b/src/shared/services/User/UserRemindHistory.js
@@ -15,7 +15,8 @@ export default class UserRemindHistory {
 
   static async getAll(userId, timeMin = null, timeMax = null) {
     const constrains = {
-      userId: userId
+      userId: userId,
+      isConfirmed: true
     }
     if (timeMin !== null || timeMax !== null) {
       constrains.createdAt = {}
@@ -28,12 +29,16 @@ export default class UserRemindHistory {
     })
   }
 
-  static async getShouldConfirm(timeMax = null) {
+  static async getShouldConfirm(timeMin = null, timeMax = null) {
     const constrains = {
       isConfirmed: false
     }
-    // createdAt <= timeMax
-    if (timeMax !== null) constrains.createdAt = {lte: timeMax}
+    if (timeMin !== null || timeMax !== null) {
+      constrains.createdAt = {}
+      // timeMin <= createdAt AND createdAt < timeMax
+      if (timeMin !== null) constrains.createdAt.gte = timeMin
+      if (timeMax !== null) constrains.createdAt.lt = timeMax
+    }
     return await models.UserRemindHistory.findAll({
       where: constrains
     })

--- a/src/shared/services/User/UserReminder.js
+++ b/src/shared/services/User/UserReminder.js
@@ -41,7 +41,8 @@ export default class UserReminder {
         time: {
           gte: min,
           lt: max
-        }
+        },
+        isActive: true
       }
     })
   }

--- a/src/shared/services/User/index.js
+++ b/src/shared/services/User/index.js
@@ -65,7 +65,7 @@ export default {
   async getRemindHistories(userId, timeMin = null, timeMax = null) {
     return await UserRemindHistory.getAll(userId, timeMin, timeMax)
   },
-  async getShouldConfirmRemindHistories(timeMax = null) {
-    return await UserRemindHistory.getShouldConfirm(timeMax)
+  async getShouldConfirmRemindHistories(timeMin = null, timeMax = null) {
+    return await UserRemindHistory.getShouldConfirm(timeMin, timeMax)
   }
 }


### PR DESCRIPTION
- 削除済みのリマインダーが通知されていたバグを修正
    - 通常通知、確認通知両方にバグがあったため対応
- 確認通知前はサマリーに含まないよう修正