### PR TITLE
削除済みのリマインダーに関するバグを修正

### DIFF
--- a/src/shared/services/User/UserRemindHistory.js
+++ b/src/shared/services/User/UserRemindHistory.js
@@ -15,7 +15,8 @@ export default class UserRemindHistory {
 
   static async getAll(userId, timeMin = null, timeMax = null) {
     const constrains = {
-      userId: userId
+      userId: userId,
+      isConfirmed: true
     }
     if (timeMin !== null || timeMax !== null) {
       constrains.createdAt = {}
@@ -28,12 +29,16 @@ export default class UserRemindHistory {
     })
   }
 
-  static async getShouldConfirm(timeMax = null) {
+  static async getShouldConfirm(timeMin = null, timeMax = null) {
     const constrains = {
       isConfirmed: false
     }
-    // createdAt <= timeMax
-    if (timeMax !== null) constrains.createdAt = {lte: timeMax}
+    if (timeMin !== null || timeMax !== null) {
+      constrains.createdAt = {}
+      // timeMin <= createdAt AND createdAt < timeMax
+      if (timeMin !== null) constrains.createdAt.gte = timeMin
+      if (timeMax !== null) constrains.createdAt.lt = timeMax
+    }
     return await models.UserRemindHistory.findAll({
       where: constrains
     })

--- a/src/shared/services/User/UserReminder.js
+++ b/src/shared/services/User/UserReminder.js
@@ -41,7 +41,8 @@ export default class UserReminder {
         time: {
           gte: min,
           lt: max
-        }
+        },
+        isActive: true
       }
     })
   }

--- a/src/shared/services/User/index.js
+++ b/src/shared/services/User/index.js
@@ -65,7 +65,7 @@ export default {
   async getRemindHistories(userId, timeMin = null, timeMax = null) {
     return await UserRemindHistory.getAll(userId, timeMin, timeMax)
   },
-  async getShouldConfirmRemindHistories(timeMax = null) {
-    return await UserRemindHistory.getShouldConfirm(timeMax)
+  async getShouldConfirmRemindHistories(timeMin = null, timeMax = null) {
+    return await UserRemindHistory.getShouldConfirm(timeMin, timeMax)
   }
 }

--- a/src/tools/Notifier.js
+++ b/src/tools/Notifier.js
@@ -10,7 +10,6 @@ const ASK_DELAY_HOURS = 1 // 通知の1時間後に確認
 export default class Notifier {
 
   static async checkOrSend() {
-    console.log('call')
     const now = new Date()
     await _notification(now) // 通知
     await _askNotification(now) // 確認通知
@@ -21,7 +20,7 @@ const _notification = async (now) => {
   // 対象のリマインダーを取得
   const mmt = moment(now)
   const min = mmt.format('HH:mm')
-  const max = mmt.add(1, 'minutes').format('HH:mm') // addは破壊型関数のため注意
+  const max = mmt.clone().add(1, 'minutes').format('HH:mm')
   const reminders = await services.User.getReminderFromTime(min, max)
 
   // 送信

--- a/src/tools/Notifier.js
+++ b/src/tools/Notifier.js
@@ -37,15 +37,17 @@ const _notification = async (now) => {
 
 const _askNotification = async (now) => {
   // 対象のリマインド履歴を取得
-  const mmt = moment(now)
-  const max = mmt.subtract(ASK_DELAY_HOURS, 'hours') // subtractは破壊型関数のため注意
-  const remindHistories = await services.User.getShouldConfirmRemindHistories(max)
+  const mmt = moment(now).subtract(ASK_DELAY_HOURS, 'hours')
+  const min = mmt.format()
+  const max = mmt.clone().add(1, 'minutes').format()
+  const remindHistories = await services.User.getShouldConfirmRemindHistories(min, max)
 
   // 送信
   // TODO: ユーザーのプラットフォームごとに切り分け
   const bot = new LineBot(config.line.channelAccessToken)
   for (const remindHistory of remindHistories) {
     const reminder = await services.User.getReminder(remindHistory.reminderId)
+    if (!reminder.isActive) continue // 削除済みの場合スキップ
     const lineUserId = await services.User.getLineUserId(reminder.userId)
     const messages = AskNotificationMessages.create(reminder, remindHistory.id)
     await bot.send(lineUserId, messages)


### PR DESCRIPTION
- 削除済みのリマインダーが通知されていたバグを修正
     - 通常通知、確認通知両方にバグがあったため対応
- 確認通知前はサマリーに含まないよう修正